### PR TITLE
feat: upgradeable Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,34 @@ Then, run `source .env`.
 
 After that, run `forge soldeer install` to obtain dependencies. And finally, run `forge build` to confirm that everything is ready.
 
-## Step 2. Deploy implementation contract
+## Step 2. Deploy KYCOneWayVault implementation contract
 
-This contract will store source code and act behind a proxy, hence it is easy to deploy it. Simply run `forge script script/DeployKYCOneWayVaultImplementation.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv` and write down the final contract address, you will need it in the next steps.
+This contract will store vault source code and act behind a proxy, hence it is easy to deploy it. Simply run `forge script script/DeployKYCOneWayVaultImplementation.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv` and write down the final contract address, you will need it in the next steps.
 
-## Step 3. Deploy BaseAccount
+## Step 3. Deploy Wrapper implementation contract
+
+This contract will store wrapper source code and act behind a proxy, hence it is easy to deploy it. Simply run `forge script script/DeployWrapperImplementation.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv` and write down the final contract address, you will need it in the next steps.
+
+## Step 4. Deploy BaseAccount
 
 Run `OWNER="" forge script script/DeployBaseAccount.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
 - `OWNER` must be set to the address, which will become a `BaseAccount` admin.
 
-## Step 4. Deploy Wrapper
+## Step 5. Deploy Wrapper
 
-Run `OWNER="" forge script script/DeployWrapper.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
-- `OWNER` must be set to the address, which will become a `Wrapper` admin.
+Run `OWNER="" IMPLEMENTATION="" forge script script/DeployWrapper.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
+- `OWNER` must be set to the address, which will become a `Wrapper` admin;
+- `IMPLEMENTATION` must be set to the contract address, obtained in step 3.
 
-## Step 5. Deploy KYCOneWayVault
+## Step 6. Deploy KYCOneWayVault
 
 Run `OWNER="" IMPLEMENTATION="" UNDERLYING_TOKEN="" DEPOSIT_ACCOUNT="" STRATEGIST="" WRAPPER="" PLATFORM="" VAULT_TOKEN_NAME="" VAULT_TOKEN_SYMBOL="" forge script script/DeployKYCOneWayVault.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
 - `OWNER` must be set to account address, which will become a `KYCOneWayVault` admin;
 - `IMPLEMENTATION` must be set to the contract address, obtained in step 2;
 - `UNDERLYING_TOKEN` is token contract address used by the vault;
-- `DEPOSIT_ACCOUNT` must be set to `BaseAccount` address deployed in step 3;
+- `DEPOSIT_ACCOUNT` must be set to `BaseAccount` address deployed in step 4;
 - `STRATEGIST` is an account address of the strategist;
-- `WRAPPER` must be set to `Wrapper` address, obtained in step 4;
+- `WRAPPER` must be set to `Wrapper` address, obtained in step 5;
 - `PLATFORM` is an account address of the platform fees recipient;
 - `VAULT_TOKEN_NAME` is an ERC20 token name for the vault token;
 - `VAULT_TOKEN_SYMBOL` is an ERC20 token symbol for the vault token.
@@ -46,14 +51,13 @@ Optionally, you might specify the following environment variables, too:
 - `DEPOSIT_CAP` is a limit of assets to be deposited (default: 0 or unlimited);
 - `STARTING_RATE` is a starting exchange rate (default is calculated on underlying token's decimals and is equal 1.0).
 
-## Step 6. Configure Wrapper
+## Step 7. Configure Wrapper
 
-Run `WRAPPER="" VAULT="" ZK_ME="" COOPERATOR="" WITHDRAWS_ENABLED="" forge script script/ConfigureWrapper.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
-- `WRAPPER` must be set to contract address, obtained in step 4;
-- `VAULT` must be set to `KYCOneWayVault` address deployed in step 5;
+Run `WRAPPER="" VAULT="" ZK_ME="" COOPERATOR="" forge script script/ConfigureWrapper.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
+- `WRAPPER` must be set to contract address, obtained in step 5;
+- `VAULT` must be set to `KYCOneWayVault` address deployed in step 6;
 - `ZK_ME` is an address of ZkMe contract;
-- `COOPERATOR` is a cooperator address provided by ZkMe;
-- `WITHDRAWS_ENABLED` is a boolean flag which controls whether withdraws will be allowed or not. Set either to `true` or `false`.
+- `COOPERATOR` is a cooperator address provided by ZkMe.
 
 ## Ownership transfer instructions
 
@@ -72,10 +76,6 @@ underlyingToken.approve(WRAPPER_ADDRESS, amount_of_tokens_to_deposit);
 ```
 
 Once the allowance is configured, users shall call the wrapper: `deposit(uint256, address)`, with the first argument being the amount of tokens to deposit and the second argument being the receiver address (normally, that would be user address).
-
-## Withdraw
-
-TODO.
 
 # Redemption rate instructions
 

--- a/script/DeployWrapper.script.sol
+++ b/script/DeployWrapper.script.sol
@@ -5,17 +5,22 @@ pragma solidity ^0.8.28;
 import {Script} from "forge-std/src/Script.sol";
 import {console} from "forge-std/src/console.sol";
 import {Wrapper} from "../src/Wrapper.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployWrapperScript is Script {
     function run() external {
         address owner = vm.envAddress("OWNER");
+        address implementation = vm.envAddress("IMPLEMENTATION");
+
+        bytes memory initializeCall = abi.encodeCall(Wrapper.initialize, (owner));
 
         vm.startBroadcast();
-        Wrapper wrapper = new Wrapper(owner);
+        ERC1967Proxy proxy = new ERC1967Proxy(implementation, initializeCall);
         vm.stopBroadcast();
 
-        console.log("Wrapper address:", address(wrapper));
+        console.log("Wrapper address:", address(proxy));
         console.log("Configuration:");
-        console.log("  Owner:", owner);
+        console.log("  Implementation:", implementation);
+        console.log("  Owner:         ", owner);
     }
 }

--- a/script/DeployWrapperImplementation.script.sol
+++ b/script/DeployWrapperImplementation.script.sol
@@ -6,15 +6,12 @@ import {Script} from "forge-std/src/Script.sol";
 import {console} from "forge-std/src/console.sol";
 import {Wrapper} from "../src/Wrapper.sol";
 
-contract DeployWrapperScript is Script {
+contract DeployWrapperImplementationScript is Script {
     function run() external {
-        Wrapper wrapper = Wrapper(vm.envAddress("WRAPPER"));
-        address vault = vm.envAddress("VAULT");
-        address zkMe = vm.envAddress("ZK_ME");
-        address cooperator = vm.envAddress("COOPERATOR");
-
         vm.startBroadcast();
-        wrapper.setConfig(vault, zkMe, cooperator);
+        Wrapper wrapper = new Wrapper();
         vm.stopBroadcast();
+
+        console.log("Wrapper address:", address(wrapper));
     }
 }

--- a/src/KYCOneWayVault.sol
+++ b/src/KYCOneWayVault.sol
@@ -622,7 +622,7 @@ contract KYCOneWayVault is
      * @param receiver Address to receive the withdrawn assets on the destination domain (as string)
      * @param owner Address that owns the shares
      */
-    function withdraw(uint256 assets, string calldata receiver, address owner) external onlyWrapper nonReentrant whenNotPaused {
+    function withdraw(uint256 assets, string calldata receiver, address owner) external nonReentrant whenNotPaused {
         if (_checkAndHandleStaleRate()) {
             return; // Exit early if vault was just paused
         }

--- a/src/Wrapper.sol
+++ b/src/Wrapper.sol
@@ -2,69 +2,103 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {OwnableUpgradeable} from "@openzeppelin-contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin-contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {KYCOneWayVault} from './KYCOneWayVault.sol';
 import {IZkMe} from './IZkMe.sol';
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract Wrapper is Ownable {
-    KYCOneWayVault public vault;
-    IZkMe public zkMe;
-    address public cooperator;
-    IERC20 public asset;
-    bool public withdrawsEnabled;
+contract Wrapper is
+    Initializable,
+    OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable
+{
+    struct Config {
+        KYCOneWayVault vault;
+        IZkMe zkMe;
+        address cooperator;
+        IERC20 asset;
+        mapping(address => bool) allowedUsers;
+    }
 
-    mapping(address => bool) allowedUsers;
+    /**
+     * @dev bytes32(uint256(keccak256('wrapper.config')) - 1)
+     */
+    bytes32 internal constant _CONFIG_SLOT = 0xc152e5a71b568a04d7b32079a68009d9daed5dc6d0ff6505f851b68b63526089;
+
+    function _getConfig() private pure returns (Config storage $) {
+        assembly {
+            $.slot := _CONFIG_SLOT
+        }
+    }
 
     error KycFailed();
 
-    error WithdrawsDisabled();
+    constructor() {
+        _disableInitializers();
+    }
 
-    constructor(address _owner) Ownable(_owner) {}
+    function initialize(address _owner) external initializer {
+        __Ownable_init(_owner);
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+    }
 
-    modifier onlyKyc() {
-        // first, check if user is explicitly approved
-        // only then ask ZkMe if user is approved
-        // saves gas, avoiding a call to ZkMe when possible
-        if (!allowedUsers[msg.sender] && !zkMe.hasApproved(cooperator, msg.sender)) {
-            revert KycFailed();
-        }
-        _;
+    function _authorizeUpgrade(address _newImplementation) internal override onlyOwner {
+        // Overloaded to protect this function to be ever called only by the owner.
     }
 
     function setConfig(
         address _vault,
         address _zkMe,
-        address _cooperator,
-        bool _withdrawsEnabled
+        address _cooperator
     ) external onlyOwner {
-        vault = KYCOneWayVault(_vault);
-        zkMe = IZkMe(_zkMe);
-        cooperator = _cooperator;
-        asset = IERC20(vault.asset());
-        withdrawsEnabled = _withdrawsEnabled;
+        Config storage config = _getConfig();
+
+        config.vault = KYCOneWayVault(_vault);
+        config.zkMe = IZkMe(_zkMe);
+        config.cooperator = _cooperator;
+        config.asset = IERC20(config.vault.asset());
     }
 
     function allowUser(address _user) external onlyOwner {
-        allowedUsers[_user] = true;
+        _getConfig().allowedUsers[_user] = true;
     }
 
     function removeUser(address _user) external onlyOwner {
-        delete allowedUsers[_user];
+        delete _getConfig().allowedUsers[_user];
     }
 
-    function deposit(uint256 assets, address receiver) external onlyKyc returns (uint256) {
-        SafeERC20.safeTransferFrom(asset, msg.sender, address(this), assets);
-        asset.approve(address(vault), assets);
-        return vault.deposit(assets, receiver);
+    function userAllowed(address _user) external view returns (bool) {
+        return _getConfig().allowedUsers[_user];
     }
 
-    function withdraw(uint256 assets, string calldata receiver) external {
-        if (!withdrawsEnabled) {
-            revert WithdrawsDisabled();
+    function deposit(uint256 assets, address receiver) external nonReentrant returns (uint256) {
+        Config storage config = _getConfig();
+
+        // First, check if user is explicitly approved inside of the Wrapper.
+        // Only then ask ZkMe if user is approved on its side.
+        // This order of execution saves gas, avoiding a call to ZkMe when possible.
+        if (!config.allowedUsers[msg.sender] && !config.zkMe.hasApproved(config.cooperator, msg.sender)) {
+            revert KycFailed();
         }
 
-        vault.withdraw(assets, receiver, msg.sender);
+        SafeERC20.safeTransferFrom(config.asset, msg.sender, address(this), assets);
+
+        config.asset.approve(address(config.vault), assets);
+        uint256 shares = config.vault.deposit(assets, receiver);
+        if (shares == 0) {
+            // The vault has paused itself, now we have to refund the user.
+            // We do not revert here since we want the vault to be able to
+            // update it's pause state successfully.
+            SafeERC20.safeTransfer(config.asset, msg.sender, assets);
+            return 0;
+        }
+
+        return shares;
     }
 }

--- a/test/KYCOneWayVault.test.sol
+++ b/test/KYCOneWayVault.test.sol
@@ -67,4 +67,12 @@ contract KYCOneWayVaultTest is Test {
         vm.expectRevert("Only wrapper allowed");
         wrapper.deposit(100, USER);
     }
+
+    function testDirectDepositForbidden() public {
+        underlyingToken.transfer(USER, 1000);
+
+        vm.startPrank(USER);
+        vm.expectRevert("Only wrapper allowed");
+        vault.deposit(100, USER);
+    }
 }


### PR DESCRIPTION
- vault now allows everyone to call `withdraw()`
- wrapper no longer wraps `withdraw()`
- wrapper is now deployed behind the proxy
- wrapper now refunds if vault refused to accept tokens on `deposit()`